### PR TITLE
Non safepointing text render

### DIFF
--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
@@ -1,0 +1,52 @@
+package org.http4s.metrics.prometheus
+
+import java.io.Writer
+
+/** This should be equivalent to [[java.io.StringWriter]] but uses
+  * a
+  */
+private[prometheus] class NonSafepointingStringWriter extends Writer {
+
+  private[this] val buf: StringBuilder = new StringBuilder()
+
+  override def write(str: String): Unit = {
+    buf.append(str)
+    ()
+  }
+
+  override def write(buff: Array[Char]): Unit = {
+    buf.append(buff)
+    ()
+  }
+
+  override def write(i: Int): Unit = {
+    buf.append(i)
+    ()
+  }
+
+  override def write(str: String, start: Int, limit: Int): Unit = write(str.slice(start, limit))
+
+  override def write(buff: Array[Char], start: Int, limit: Int): Unit = write(
+    buff.slice(start, limit)
+  )
+
+  override def append(c: Char): Writer = {
+    buf.append(c)
+    this
+  }
+
+  override def append(cs: CharSequence): Writer = {
+    buf.append(cs)
+    this
+  }
+
+  override def append(cs: CharSequence, start: Int, limit: Int): Writer =
+    append(cs.subSequence(start, limit))
+
+  override def flush(): Unit = ()
+
+  override def close(): Unit = ()
+
+  override def toString(): String = buf.toString()
+
+}

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2018 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.metrics.prometheus
 
 import java.io.Writer
 
 /** This should be equivalent to [[java.io.StringWriter]] but uses
   * a [[java.lang.StringBuilder]] rather than a [[java.lang.StringBuffer]]
-  * and consequently is not `synchronized
+  * and consequently is not synchronized
   */
 private[prometheus] class NonSafepointingStringWriter extends Writer {
 
@@ -42,7 +58,7 @@ private[prometheus] class NonSafepointingStringWriter extends Writer {
   }
 
   override def append(cs: CharSequence, start: Int, limit: Int): Writer =
-    // ¯\_(ツ)_/¯
+    // Replicating behaviour of StringWriter ¯\_(ツ)_/¯
     if (cs == null) append("null")
     else
       append(cs.subSequence(start, limit))

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
@@ -21,7 +21,7 @@ private[prometheus] class NonSafepointingStringWriter extends Writer {
   }
 
   override def write(i: Int): Unit = {
-    buf.append(i)
+    buf.append(i.toChar)
     ()
   }
 

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
@@ -3,7 +3,8 @@ package org.http4s.metrics.prometheus
 import java.io.Writer
 
 /** This should be equivalent to [[java.io.StringWriter]] but uses
-  * a
+  * a [[java.lang.StringBuilder]] rather than a [[java.lang.StringBuffer]]
+  * and consequently is not synchronized
   */
 private[prometheus] class NonSafepointingStringWriter extends Writer {
 

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/NonSafepointingStringWriter.scala
@@ -4,7 +4,7 @@ import java.io.Writer
 
 /** This should be equivalent to [[java.io.StringWriter]] but uses
   * a [[java.lang.StringBuilder]] rather than a [[java.lang.StringBuffer]]
-  * and consequently is not synchronized
+  * and consequently is not `synchronized
   */
 private[prometheus] class NonSafepointingStringWriter extends Writer {
 
@@ -42,7 +42,10 @@ private[prometheus] class NonSafepointingStringWriter extends Writer {
   }
 
   override def append(cs: CharSequence, start: Int, limit: Int): Writer =
-    append(cs.subSequence(start, limit))
+    // ¯\_(ツ)_/¯
+    if (cs == null) append("null")
+    else
+      append(cs.subSequence(start, limit))
 
   override def flush(): Unit = ()
 

--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
@@ -25,8 +25,6 @@ import org.http4s.Uri.Path
 import org.http4s._
 import org.http4s.syntax.all._
 
-import java.io.StringWriter
-
 /*
  * PrometheusExportService Contains an HttpService
  * ready to be scraped by Prometheus, paired
@@ -54,7 +52,7 @@ object PrometheusExportService {
   def generateResponse[F[_]: Sync](collectorRegistry: CollectorRegistry): F[Response[F]] =
     Sync[F]
       .delay {
-        val writer = new StringWriter
+        val writer = new NonSafepointingStringWriter()
         TextFormat.write004(writer, collectorRegistry.metricFamilySamples)
         writer.toString
       }

--- a/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusExportServiceSuite.scala
+++ b/prometheus-metrics/src/test/scala/org/http4s/metrics/prometheus/PrometheusExportServiceSuite.scala
@@ -1,0 +1,46 @@
+package org.http4s.metrics.prometheus
+
+/*
+ * Copyright 2018 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.metrics.prometheus
+
+import cats.effect._
+import munit.CatsEffectSuite
+import _root_.org.http4s._
+import _root_.org.http4s.dsl.io._
+import _root_.org.http4s.implicits._
+
+class PrometheusClientMetricsSuite extends CatsEffectSuite {
+
+  test("Returns Prometheus-format") {
+    PrometheusExportService.build[IO].use { svc =>
+      svc.routes.orNotFound
+        .run(Request(method = GET, uri = Uri.unsafeFromString("/metrics")))
+        .flatMap(resp => resp.body.compile.to(Array).map(new String(_)))
+        .flatMap { resp =>
+          IO {
+            println(resp)
+            val lines = resp.lines().toList
+            // Assortment of lines that should appear in the output as a sanity check
+            assert(clue(lines).contains("# TYPE jvm_memory_pool_allocated_bytes_total counter"))
+            assert(clue(lines).contains("# HELP jvm_threads_daemon Daemon thread count of a JVM"))
+          }
+        }
+    }
+  }
+
+}


### PR DESCRIPTION
`StringWriter` is based on `java.io.StringBuffer`, which synchronizes every write. Our usage of `Writer` instances is entirely local so this is a _huge_ safepoint penalty to pay for no benefit.