### PR TITLE
Support Openmetrics metrics format

### DIFF
--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
@@ -23,7 +23,6 @@ import io.prometheus.client.exporter.common.TextFormat
 import io.prometheus.client.hotspot._
 import org.http4s.Uri.Path
 import org.http4s._
-import org.http4s.headers.Accept
 import org.http4s.syntax.all._
 import org.typelevel.ci.CIString
 


### PR DESCRIPTION
This allows metrics to formatted using openmetrics format with exemplar support.

A number of options are available for changing the format. The default now supports reading the `accept` header, which aligns with the default behaviour of the Java library. Users can also specify hard coded implementations depending on their need.