### PR TITLE
Wrap generating response in `Sync[F].blocking`.

### DIFF
--- a/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
+++ b/prometheus-metrics/src/main/scala/org/http4s/metrics/prometheus/PrometheusExportService.scala
@@ -77,7 +77,7 @@ object PrometheusExportService {
   ): F[Response[F]] = for {
     parsedContentType <- Sync[F].delay(TextFormat.chooseContentType(contentType))
     text <- Sync[F]
-      .delay {
+      .blocking {
         val writer = new NonSafepointingStringWriter()
         TextFormat.writeFormat(
           parsedContentType,


### PR DESCRIPTION
Fixes #133.