### PR TITLE
Add sample server repo link to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,9 @@ val meteredRouter: Resource[IO, HttpRoutes[IO]] =
   } yield router
 ```
 
+### Example Project
+Refer to [this example project](https://github.com/martinprobson/http4s_prometheus_example) that publishes the default server metrics and exposes them on a sample Grafana dashboard. 
+
 ## Client example
 
 ```scala mdoc:reset:silent


### PR DESCRIPTION
Hello, I spent a bit of time understanding the library and putting together a sample project that uses the default server metrics and publishes them to a Grafana dashboard. 

I thought this might be generally useful to people looking for information on how to use this library, so I have included a link to the example project in the docs.

Please feel free to use as is or clone the whole repo if you want.
 